### PR TITLE
Openshift compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
   "name": "nodejs-demo",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "scripts": {
+    "start": "node server.js"
+  }
 }


### PR DESCRIPTION
In addition to a valid `package.json`, Openshift requires a `start` script.